### PR TITLE
Portability fixes upstreamed from pkgsrc

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -44,7 +44,15 @@ AC_HEADER_STDC
 AC_CHECK_HEADERS( \
   getopt.h \
   stdbool.h \
+  stdint.h \
   pthread.h \
+  linux/fs.h \
+  sys/devinfo.h \
+  sys/disk.h \
+  sys/dkio.h \
+  sys/ioctl.h \
+  sys/scsi.h \
+  sys/mman.h \
 )
 
 AC_PROG_LIBTOOL
@@ -55,6 +63,12 @@ AC_PKGCONFIG
 ## 
 AC_C_BIGENDIAN
 AC_C_CONST
+
+##
+# Checks for libraries
+##
+AC_CHECK_LIB(prop, prop_dictionary_recv_ioctl, LIBPROP=-lprop)
+AC_SUBST(LIBPROP)
 
 ##
 # Checks for library functions

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -23,4 +23,4 @@ scrub_SOURCES = \
 	util.c \
 	util.h
 
-scrub_LDADD = $(LIBPTHREAD)
+scrub_LDADD = $(LIBPTHREAD) $(LIBPROP)

--- a/src/getsize.c
+++ b/src/getsize.c
@@ -35,16 +35,35 @@
 #include <stdlib.h>
 #include <libgen.h>
 #include <string.h>
+#if HAVE_STDINT_H
+#include <stdint.h>
+#endif
+#if HAVE_SYS_IOCTL_H
+#include <sys/ioctl.h>
+#endif
+#if HAVE_LINUX_FS_H
+#include <linux/fs.h>
+#endif
+#if HAVE_SYS_DEVINFO_H
+#include <sys/devinfo.h>
+#endif
+#if HAVE_SYS_DISK_H
+#include <sys/disk.h>
+#endif
+#if HAVE_SYS_DKIO_H
+#include <sys/dkio.h>
+#endif
+#if HAVE_SYS_SCSI_H
+#include <sys/scsi.h>
+#endif
 
 #include "getsize.h"
 
 extern char *prog;
 
-#if defined(linux)
+#if defined (BLKGETSIZE) && defined(BLKGETSIZE64)
 /* scrub-1.7 tested linux 2.6.11-1.1369_FC4 */
 /* scrub-1.8 tested Fedora Core 5 */
-#include <sys/ioctl.h>
-#include <linux/fs.h>
 #include <sys/utsname.h>
 typedef unsigned long long u64; /* for BLKGETSIZE64 (slackware) */
 
@@ -85,11 +104,8 @@ error:
     return -1;
 }
 
-#elif defined(__FreeBSD__)
+#elif defined(DIOCGMEDIASIZE)
 /* scrub-1.7 tested freebsd 5.3-RELEASE-p5 */
-#include <sys/ioctl.h>
-#include <sys/disk.h>
-
 int
 getsize(char *path, off_t *sizep)
 {
@@ -110,10 +126,8 @@ error:
     return -1;
 }
 
-#elif defined(sun)
+#elif defined(DKIOCGMEDIAINFO)
 /* scrub-1.7 tested solaris 5.9 */
-#include <sys/ioctl.h>
-#include <sys/dkio.h>
 #include <sys/vtoc.h>
 
 int
@@ -136,11 +150,8 @@ error:
     return -1;
 }
 
-#elif defined(__APPLE__)
+#elif defined(DKIOCGETBLOCKSIZE) && defined(DKIOCGETBLOCKCOUNT)
 /* scrub-1.7 tested OS X 7.9.0 */
-#include <stdint.h>
-#include <sys/ioctl.h>
-#include <sys/disk.h>
 
 int
 getsize(char *path, off_t *sizep)
@@ -164,11 +175,10 @@ error:
         (void)close(fd);
     return -1;
 }
-#elif defined(_AIX)
+
+#elif defined(IOCINFO)
 /* scrub-1.7 tested AIX 5.1 and 5.3 */
 /* scrub-1.8 tested AIX 5.2 */
-#include <sys/ioctl.h>
-#include <sys/devinfo.h>
 
 int
 getsize(char *path, off_t *sizep)
@@ -206,10 +216,10 @@ error:
         (void)close(fd);
     return -1;
 }
-#elif defined (__hpux)
+
+#elif defined (SIOC_CAPACITY)
 
 #include <stropts.h>
-#include <sys/scsi.h>
 
 int
 getsize(char *path, off_t *sizep)
@@ -231,11 +241,43 @@ error:
     return -1;
 }
 
+#elif defined(DIOCGDISKINFO)
+
+int
+getsize(char *path, off_t *sizep)
+{
+    int fd;
+    prop_dictionary_t disk_dict, geom_dict;
+    uint64_t secperunit;
+    uint32_t secsize;
+
+    fd = open(path, O_RDONLY);
+    if (fd == -1)
+        return -1;
+
+    if (prop_dictionary_recv_ioctl(fd, DIOCGDISKINFO, &disk_dict) != 0)
+        return -1;
+    if (close(fd) == -1)
+        return -1;
+
+    geom_dict = prop_dictionary_get(disk_dict, "geometry");
+    if (geom_dict == NULL)
+        return -1;
+
+    if (!prop_dictionary_get_uint64(geom_dict, "sectors-per-unit", &secperunit))
+        return -1;
+    if (!prop_dictionary_get_uint32(geom_dict, "sector-size",      &secsize))
+        return -1;
+    *sizep = secperunit * secsize;
+
+    return 0;
+}
+
 #else
 /* Unimplemented!  Scrub will tell user to use -s.
  */
-off_t 
-getsize(char *path)
+int
+getsize(char *path, off_t *sizep)
 {
     errno = ENOSYS;
     return -1;

--- a/src/util.h
+++ b/src/util.h
@@ -4,6 +4,10 @@
 typedef enum { false, true } bool;
 #endif
 
+#ifdef HAVE_SYS_MMAN_H
+#include <sys/mman.h>
+#endif
+
 typedef enum {
     FILE_NOEXIST,
     FILE_REGULAR,

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -26,4 +26,6 @@ tgetsize_SOURCES = tgetsize.c $(common_sources)
 tsig_SOURCES = tsig.c $(common_sources)
 pat_SOURCES = pat.c $(common_sources)
 
+LDADD = $(LIBPROP)
+
 EXTRA_DIST = $(TESTS) $(TESTS:%=%.exp)


### PR DESCRIPTION
Taken from http://cvsweb.netbsd.org/bsdweb.cgi/pkgsrc/sysutils/diskscrub
Various changes which improve the portability of the codebase & resolve build issue on some platforms.

- Use ioctl names (feature tests) rather than OS names.
  XXX for SIOC_CAPACITY consider using SIOC_STORAGE_CAPACITY.
- Implement getsize() based on DIOCGDISKINFO ioctl.
- Check for sys/mman.h & use it in src/util.h as off_t is defined there on
  FreeBSD.