### PR TITLE
scrub should work for symlinks pointing to block devices

### DIFF
--- a/src/util.c
+++ b/src/util.c
@@ -71,6 +71,15 @@ write_all(int fd, const unsigned char *buf, int count)
     return n;
 }
 
+/* Indicates whether the file represented by 'path' is a symlink.
+ */
+int
+is_symlink(char *path)
+{
+    struct stat sb;
+    return lstat(path, &sb) == 0 && S_ISLNK(sb.st_mode);
+}
+
 /* Return the type of file represented by 'path'.
  */
 filetype_t
@@ -79,10 +88,6 @@ filetype(char *path)
     struct stat sb;
 
     filetype_t res = FILE_NOEXIST;
-
-    if (lstat(path, &sb) == 0 && S_ISLNK(sb.st_mode)) {
-        return FILE_LINK;
-    }
 
     if (stat(path, &sb) == 0) {
         if (S_ISREG(sb.st_mode))

--- a/src/util.h
+++ b/src/util.h
@@ -13,7 +13,6 @@ typedef enum {
     FILE_REGULAR,
     FILE_CHAR,
     FILE_BLOCK,
-    FILE_LINK,
     FILE_OTHER,
 } filetype_t;
 
@@ -21,6 +20,7 @@ typedef enum { UP, DOWN } round_t;
 
 int         read_all(int fd, unsigned char *buf, int count);
 int         write_all(int fd, const unsigned char *buf, int count);
+int         is_symlink(char *path);
 filetype_t  filetype(char *path);
 off_t       blkalign(off_t offset, int blocksize, round_t rtype);
 void *      alloc_buffer(int bufsize);


### PR DESCRIPTION
In [1] (add -L option to avoid scrubbing symlink target [Tim
Boronczyk]), scrub introduced a -L (--no-link) option so that it would
not scrub the target, if it was a link and this new option was set.

A side-effect of that change is that scrub stopped working for links
pointing to a block device, whereas it would still work for links
pointing to regular files -- it is not clear from the commit changelog
and the added documentation for this new option that this was an
intended change.

In this commit we fix this regression, and scrub works again for links
pointing to block devices. -L/--no-link option also works for these
links.

Resolves: #19

[1] https://github.com/chaos/scrub/commit/01915c442288b4b274261fa07e42e116fb9d6b60