### PR TITLE
Use libgcrypt by default instead of custom crypto

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -85,6 +85,25 @@ AC_CHECK_FUNCS( \
 X_AC_CHECK_PTHREADS
 
 ##
+# gcrypt library
+##
+have_libgcrypt=no
+AC_ARG_WITH(libgcrypt, AS_HELP_STRING([--without-libgcrypt], [build without libgcrypt;
+                                         fallback to custom AES implementation]))
+AS_IF([test "x$with_libgcrypt" != "xno"],
+  [AM_PATH_LIBGCRYPT([1.5.0],
+    [AC_DEFINE([HAVE_LIBGCRYPT], [1], [libgcrypt API available])
+      gcrypt_CFLAGS="$LIBGCRYPT_CFLAGS"
+      gcrypt_LIBS="$LIBGCRYPT_LIBS"
+      have_libgcrypt=yes
+    ]
+  )]
+)
+AM_CONDITIONAL([LIBGCRYPT], [test "$have_libgcrypt" = "yes"])
+AC_SUBST([gcrypt_CFLAGS])
+AC_SUBST([gcrypt_LIBS])
+
+##
 # Arrange for large file support
 ## 
 AC_SYS_LARGEFILE

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1,8 +1,6 @@
 bin_PROGRAMS = scrub
 
 scrub_SOURCES = \
-	aes.c \
-	aes.h \
 	filldentry.c \
 	filldentry.h \
 	fillfile.c \
@@ -24,3 +22,9 @@ scrub_SOURCES = \
 	util.h
 
 scrub_LDADD = $(LIBPTHREAD) $(LIBPROP)
+
+if LIBGCRYPT
+scrub_LDADD += $(gcrypt_LIBS)
+else
+scrub_SOURCES += aes.c aes.h
+endif

--- a/src/genrand.h
+++ b/src/genrand.h
@@ -1,7 +1,13 @@
+#include "config.h"
+
 void disable_hwrand(void);
 int initrand(void);
-int churnrand(void);
 void genrand(unsigned char *buf, int buflen);
+
+#ifndef HAVE_LIBGCRYPT
+int churnrand(void);
+#endif /* HAVE_LIBGCRYPT. */
+
 
 /*
  * vi:tabstop=4 shiftwidth=4 expandtab

--- a/src/scrub.c
+++ b/src/scrub.c
@@ -467,11 +467,13 @@ scrub(char *path, off_t size, const sequence_t *seq, int bufsize,
             case PAT_RANDOM:
                 printf("%s: %-8s", prog, "random");
                 progress_create(&p, pcol);
+#ifndef HAVE_LIBGCRYPT
                 if (churnrand() < 0) {
                     fprintf(stderr, "%s: churnrand: %s\n", prog,
                              strerror(errno));
                     exit(1);
                 }
+#endif /* HAVE_LIBGCRYPT. */
                 written = fillfile(path, size, buf, bufsize, 
                                    (progress_t)progress_update, p, 
                                    (refill_t)genrand, sparse, enospc);

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -1,8 +1,8 @@
-check_PROGRAMS = pad trand aestest tprogress tgetsize tsig tsize pat
+check_PROGRAMS = pad trand tprogress tgetsize tsig tsize pat
 
 TESTS_ENVIRONMENT = env 
 TESTS_ENVIRONMENT += "PATH_SCRUB=$(top_builddir)/src/scrub"
-TESTS = t00 t01 t02 t03 t04 t05 t06 t07 t08 t09 t10 t11 t12 t13 t14 t15 t16 \
+TESTS = t01 t02 t03 t04 t05 t06 t07 t08 t09 t10 t11 t12 t13 t14 t15 t16 \
 	t17 t18 t19 t20 t21 t22
 
 CLEANFILES = *.out *.diff testfile
@@ -13,18 +13,25 @@ common_sources = \
 	$(top_srcdir)/src/getsize.c \
 	$(top_srcdir)/src/genrand.c \
 	$(top_srcdir)/src/hwrand.c \
-	$(top_srcdir)/src/aes.c \
 	$(top_srcdir)/src/util.c \
 	$(top_srcdir)/src/progress.c \
 	$(top_srcdir)/src/sig.c
 
 pad_SOURCES = pad.c $(common_sources)
 trand_SOURCES = trand.c $(common_sources)
-aestest_SOURCES = aestest.c $(common_sources)
 tprogress_SOURCES = tprogress.c $(common_sources)
 tgetsize_SOURCES = tgetsize.c $(common_sources)
 tsig_SOURCES = tsig.c $(common_sources)
 pat_SOURCES = pat.c $(common_sources)
+
+if LIBGCRYPT
+AM_LDFLAGS = $(gcrypt_LIBS)
+else
+check_PROGRAMS += aestest
+TESTS += t00
+common_sources += $(top_srcdir)/src/aes.c
+aestest_SOURCES = aestest.c $(common_sources)
+endif
 
 LDADD = $(LIBPROP)
 


### PR DESCRIPTION
When libgcrypt is available, use it instead of our custom AES
implementation.

If we want to use the legacy AES code, we can disable libgcrypt
explictly with --disable-libgcrypt.

Based on a patch by Daniel Kopecek.