### PR TITLE
Initial scrub.conf enhancement commit

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -14,4 +14,7 @@ dist_doc_DATA = \
 	README \
 	README.md
 
+scrubdir = $(datadir)/scrub
+scrub_DATA = scrub.conf.sample
+
 EXTRA_DIST = META scrub.spec

--- a/configure.ac
+++ b/configure.ac
@@ -117,6 +117,7 @@ AC_CONFIG_FILES( \
   src/Makefile \
   man/Makefile \
   man/scrub.1 \
+  man/scrub.conf.5 \
   test/Makefile \
   libscrub/Makefile \
   libscrub/libscrub.pc \

--- a/man/Makefile.am
+++ b/man/Makefile.am
@@ -1,4 +1,5 @@
 man1_MANS = scrub.1
+man5_MANS = scrub.conf.5
 
-EXTRA_DIST = scrub.1
+EXTRA_DIST = scrub.1 scrub.conf.5
 

--- a/man/scrub.1.in
+++ b/man/scrub.1.in
@@ -262,4 +262,4 @@ http://cmrr.ucsd.edu/people/Hughes/DataSanitizationTutorial.pdf.
 "Guidelines for Media Sanitization", NIST special publication 800-88,
 Kissel et al, September, 2006.
 .LP
-shred(1), hdparm(8)
+shred(1), scrub.conf(5), hdparm(8)

--- a/man/scrub.conf.5.in
+++ b/man/scrub.conf.5.in
@@ -1,0 +1,57 @@
+.TH scrub.conf 5 "@META_DATE@" "@META_ALIAS@" "@META_NAME@"
+.nh
+.SH NAME
+scrub.conf \- Local Settings File
+.SH SYNOPSIS
+.B $HOME/.scrub.conf
+.br
+.SH DESCRIPTION
+\fBscrub.conf\fR stores configuration information that may be
+used by \fBscrub\fR.
+.SH OPTIONS
+.B scrub.conf
+may contain any of the following Parameter=Value
+settings.
+.TP
+.B BLOCKSIZE\fR = {valid scrub block size, #[Kk|Mm|Gg]}
+Blocksize is a number followed by modifier: K|k for Kilobytes,
+M|m for Megabytes, G|g for Gigabytes. Default is 4 Megabytes. 
+.br
+(Note. limit is bounded by off_t, 2G)
+.TP
+.B PATTERN\fR = {valid scrub pattern}
+Valid patterns are: nnsa, dod, bsi, usarmy,
+random, random2, schneier, pfitzner7, pfitzner33, gutmann,
+fastold, old, dirent, fillzero, fillff, verify. Custom patterns
+may not be placed in conf file.
+.TP
+.B FORCE\fR = {0,1,FALSE,TRUE}
+Scrub device/file even if scrub signature is present.
+.TP
+.B NOSIGNATURE\fR = {0,1,FALSE,TRUE}
+Do not write scrub signature on device/file.
+.TP
+.B REMOVE\fR = {0,1,FALSE,TRUE}
+Remove file after scrub.
+.TP
+.B NOLINK\fR = {0,1,FALSE,TRUE}
+Do not follow links for scrub.
+.TP
+.B NOHWRAND\fR = {0,1,FALSE,TRUE}
+Do not use Hardware-based Randon Number Generator.
+.TP
+.B NOTHREADS\fR = {0,1,FALSE,TRUE}
+Do not use threading.
+\.TP
+
+Parameter names must be in column 1. Lines beginning with a \fI'#'\fR or \fI'space'\fR are ignored.
+.SH FILES
+.I $HOME/.scrub.conf
+.RS
+Local user configuration settings for
+.B scrub\fR.
+.SH AUTHOR
+Peter Hyman <pete@peterhyman.com>
+.SH SEE ALSO
+.BR scrub(1)
+

--- a/scrub.conf.sample
+++ b/scrub.conf.sample
@@ -1,0 +1,33 @@
+##### scrub.conf file #####
+# Must Reside in: $HOME/.scrub.conf
+# Lines beginning with # or space(s) ignored.
+#
+# Offers the following fixed parameters for scrub
+#  BLOCKSIZE = number followed by Kk,Mm,Gg (-b 4m is default)
+#  Block size limited to off_t, 2G
+#  PATTERN = valid pattern name excl custom (-p pat)
+#  FORCE = 0,1,FALSE,TRUE (-f)
+#  NOSIGNATURE = 0,1,FALSE,TRUE (-S)
+#  REMOVE = 0,1,FALSE,TRUE (-r)
+#  NOLINK = 0,1,FALSE,TRUE (-L)
+#  NOHWRAND = 0,1,FALSE,TRUE (-R)
+#  NOTHREADS = 0,1,FALSE,TRUE (-t)
+# valid patterns are: nnsa, dod, bsi, usarmy, random, random2
+#  schneier, pfitzner7, pfitzner33, gutmann, fastold, old
+#  dirent, fillzero, fillff, verify
+# custom pattern strings not accepted
+#
+# Parameter names are case sensitive.
+# Pattern value is case sensitive.
+# Boolean words TRUE and FALSE are not case sensitive.
+##### scrub.conf file #####
+# default values shown. can be overridden on command line
+
+#BLOCKSIZE=4m
+#PATTERN=nnsa
+#FORCE=FALSE
+#NOSIGNATURE=FALSE
+#REMOVE=FALSE
+#NOLINK=FALSE
+#NOHWRAND=FALSE
+#NOTHREADS=FALSE

--- a/scrub.spec.in
+++ b/scrub.spec.in
@@ -42,6 +42,7 @@ rm -rf $RPM_BUILD_ROOT
 %doc ChangeLog NEWS DISCLAIMER COPYING INSTALL README
 %{_bindir}/scrub
 %{_mandir}/man1/*
+%{_mandir}/man5/*
 
 %changelog
 * Tue Feb 14 2006 Ben Woodard <woodard@redhat.com> 1.7-1

--- a/src/scrub.c
+++ b/src/scrub.c
@@ -52,23 +52,6 @@
 #include "getsize.h"
 #include "progress.h"
 #include "sig.h"
-#include "pattern.h"
-
-#define BUFSIZE (4*1024*1024) /* default blocksize */
-
-struct opt_struct {
-    const sequence_t *seq;
-    int blocksize;
-    off_t devsize;
-    char *dirent;
-    bool force;
-    bool nosig;
-    bool remove;
-    bool sparse;
-    bool nofollow;
-    bool nohwrand;
-    bool nothreads;
-};
 
 static bool       scrub(char *path, off_t size, const sequence_t *seq,
                       int bufsize, bool nosig, bool sparse, bool enospc);
@@ -110,26 +93,38 @@ static struct option longopts[] = {
 char *prog;
 
 static void 
-usage(int rc)
+usage(int rc, struct opt_struct opt, bool Pconf)
 {
     FILE *fp = rc ? stderr : stdout;
     fprintf(fp,
-"Usage: %s [OPTIONS] file [file...]\n"
-"  -v, --version           display scrub version and exit\n"
-"  -p, --pattern pat       select scrub pattern sequence\n"
-"  -b, --blocksize size    set I/O buffer size (default 4m)\n"
-"  -s, --device-size size  set device size manually\n"
-"  -X, --freespace dir     create dir+files, fill until ENOSPC, then scrub\n"
-"  -D, --dirent newname    after scrubbing file, scrub dir entry, rename\n"
-"  -f, --force             scrub despite signature from previous scrub\n"
-"  -S, --no-signature      do not write scrub signature after scrub\n"
-"  -r, --remove            remove file after scrub\n"
-"  -L, --no-link           do not scrub link target\n"
-"  -R, --no-hwrand         do not use a hardware random number generator\n"
-"  -t, --no-threads        do not compute random data in a parallel thread\n"
-"  -n, --dry-run           verify file arguments, without writing\n"
-"  -h, --help              display this help message\n"
-    , prog);
+"%s Version: %s: %s\n\
+Usage: %s [OPTIONS] file [file...]\n\
+  -v, --version           display scrub version and exit\n\
+  -p, --pattern pat       select scrub pattern sequence (default %s)\n\
+  -b, --blocksize size    set I/O buffer size (default %d)\n\
+  -s, --device-size size  set device size manually\n\
+  -X, --freespace dir     create dir+files, fill until ENOSPC, then scrub\n\
+  -D, --dirent newname    after scrubbing file, scrub dir entry, rename\n\
+  -f, --force             scrub despite signature from previous scrub (default %s)\n\
+  -S, --no-signature      do not write scrub signature after scrub (default %s)\n\
+  -r, --remove            remove file after scrub (default %s)\n\
+  -L, --no-link           do not scrub link target (default %s)\n\
+  -R, --no-hwrand         do not use a hardware random number generator (default %s)\n\
+  -t, --no-threads        do not compute random data in a parallel thread (default %s)\n\
+  -n, --dry-run           verify file arguments, without writing\n\
+  -h, --help              display this help message\n"
+    , prog
+    , VERSION
+    , Pconf ? "options from scrub.conf":"program defaults"
+    , prog
+    , opt.seq ? opt.seq->key:"nnsa"
+    , opt.blocksize ? opt.blocksize:4194304
+    , opt.force ? "True":"False"
+    , opt.nosig ? "True":"False"
+    , opt.remove ? "True":"False"
+    , opt.nofollow ? "True":"False"
+    , opt.nohwrand ? "True":"False"
+    , opt.nothreads ? "True":"False" );
 
     fprintf(fp, "Available patterns are:\n");
     seq_list (fp);
@@ -144,6 +139,7 @@ main(int argc, char *argv[])
     bool Xopt = false;
     bool nopt = false;
     bool Dopt = false;  /* Rename flag */
+    bool Pconf = false; /* Pattern returned from Conf file */
     extern int optind;
     extern char *optarg;
     int c;
@@ -151,7 +147,14 @@ main(int argc, char *argv[])
     assert(sizeof(off_t) == 8);
 
     memset (&opt, 0, sizeof (opt));
-    opt.blocksize = BUFSIZE;
+
+    /* Read scrub.conf file for constant settings */
+    read_conf( &opt );
+    if ( opt.seq )
+        Pconf = true;
+    else
+        opt.blocksize = BUFSIZE;
+
 
     /* Handle arguments.
      */
@@ -162,7 +165,8 @@ main(int argc, char *argv[])
             printf("scrub version %s\n", VERSION);
             exit(0);
         case 'p':   /* --pattern */
-            if (opt.seq != NULL) {
+                    /* can override if set in conf file */
+            if (opt.seq != NULL && !Pconf ) {
                 fprintf(stderr, "%s: only one pattern can be selected\n", prog);
                 exit(1);
             }
@@ -228,16 +232,16 @@ main(int argc, char *argv[])
             nopt = true;
             break;
         case 'h':   /* --help */
-            usage(0);
+            usage(0, opt, Pconf);
             break;
         default:
-            usage(1);
+            usage(1, opt, Pconf);
         }
     }
     if (argc == optind) {
         if (Dopt)   /* -D specified but no newname specified */
             fprintf( stderr, "%s: -D requires a rename argument\n\n", prog);
-        usage(1);
+        usage(1, opt, Pconf);
     }
     if (Xopt && argc - optind > 1) {
         fprintf(stderr, "%s: -X only takes one directory name\n", prog);

--- a/src/util.c
+++ b/src/util.c
@@ -26,13 +26,16 @@
 #if HAVE_CONFIG_H
 #include "config.h"
 #endif
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <errno.h>
 #include <unistd.h>
 #include <libgen.h>
-#include <stdlib.h>
-
+#include <ctype.h>
+#include "getsize.h"
 #include "util.h"
 
 /* Handles short reads but otherwise just like read(2).
@@ -144,6 +147,110 @@ alloc_buffer(int bufsize)
 #endif
 
     return ptr;
+}
+
+/* check for scrub.conf in home directory only
+ * code inspiration from lrzip application
+ * by Con Kolivas
+ * Valid Parameters and Values are:
+ * PATTERN = valid pattern name excl custom (-p pat)
+ * FORCE = 0,1,FALSE,TRUE (-f)
+ * NOSIGNATURE = 0,1,FALSE,TRUE (-S)
+ * REMOVE = 0,1,FALSE,TRUE (-r)
+ * NOLINK = 0,1,FALSE,TRUE (-L)
+ * NOHWRAND = 0,1,FALSE,TRUE (-R)
+ * NOTHREADS = 0,1,FALSE,TRUE (-t)
+ *
+*/
+void
+read_conf( struct opt_struct *opt )
+{
+    char *HOME;
+    char *parameter;
+    char *parametervalue;
+    char *homeconf;
+    char *line;
+    int blocksize;
+    FILE *fp;
+
+    HOME=getenv("HOME");
+    if ( HOME == NULL )
+        return;
+
+    /* alloc sizeof HOME + len /.scrub.conf + 1 */
+    homeconf = malloc( strlen(HOME)+13 );
+    line = malloc( 255 );
+    if ( homeconf == NULL || line == NULL ) {
+        fprintf( stderr, "%s: Very Serious Memory Allocation Error: read_conf", "scrub" );
+        exit(1);
+    }
+
+    /* $HOME/.scrub.conf */
+    snprintf( homeconf, strlen(HOME)+13, "%s/.scrub.conf", HOME );
+
+    /* open $HOME/.scrub.conf if available */
+    fp = fopen( homeconf, "r" );
+    if ( fp ) {
+        while ( fgets(line, 255 , fp) != NULL ) {
+            if ( strlen(line) )
+                line[strlen(line) - 1] = '\0';
+            parameter = strtok(line, " =");
+            /* skip if blank line, space, or # */
+            if ( parameter == NULL || isspace(*parameter) || *parameter == '#' )
+                continue;
+
+            parametervalue = strtok(NULL, " =");
+            if ( parametervalue == NULL )
+                continue;
+
+            /* we have a valid parameter line */
+
+            if ( !strcmp(parameter, "BLOCKSIZE") ) {
+                if ( (blocksize = str2int(parametervalue)) > 0 )
+                    opt->blocksize = blocksize;
+                else
+                    fprintf( stderr, "%s: Invalid Block Size in scrub.conf. Ignored: %s. Default will be used: %d\n", "scrub", parameter, BUFSIZE );
+
+            }
+            else if ( !strcmp(parameter, "PATTERN") ) {
+                opt->seq = seq_lookup(parametervalue);
+                if ( opt->seq == NULL )
+                    fprintf( stderr, "%s: Invalid Pattern: %s. Ignored", "scrub", parametervalue );
+            }
+            else if ( !strcmp(parameter, "FORCE") ) {
+                if ( !strcmp(parametervalue, "1") || !strcasecmp(parametervalue,"TRUE") )
+                    opt->force = true;
+            }
+            else if ( !strcmp(parameter, "NOSIGNATURE") ) {
+                if ( !strcmp(parametervalue, "1") || !strcasecmp(parametervalue,"TRUE") )
+                    opt->nosig = true;
+            }
+            else if ( !strcmp(parameter, "REMOVE") ) {
+                if ( !strcmp(parametervalue, "1") || !strcasecmp(parametervalue,"TRUE") )
+                    opt->remove = true;
+            }
+            else if ( !strcmp(parameter, "NOLINK") ) {
+                if ( !strcmp(parametervalue, "1") || !strcasecmp(parametervalue,"TRUE") )
+                    opt->nofollow = true;
+            }
+            else if ( !strcmp(parameter, "NOHWRAND") ) {
+                if ( !strcmp(parametervalue, "1") || !strcasecmp(parametervalue,"TRUE") )
+                    opt->nohwrand = true;
+            }
+            else if ( !strcmp(parameter, "NOTHREADS") ) {
+                if ( !strcmp(parametervalue, "1") || !strcasecmp(parametervalue,"TRUE") )
+                    opt->nothreads = true;
+            }
+            else
+                fprintf( stderr, "%s: Invalid Parameter in scrub.conf. Ignored: %s\n", "scrub", parameter );
+        }
+        if ( fclose(fp) ) {
+            fprintf( stderr, "%s: Error closing %s.", "scrub", homeconf );
+            exit(1);
+        }
+    } /* scrub.conf read complete */
+    free( homeconf );
+    free( line );
 }
 
 /*

--- a/src/util.h
+++ b/src/util.h
@@ -8,6 +8,10 @@ typedef enum { false, true } bool;
 #include <sys/mman.h>
 #endif
 
+#include "pattern.h"
+
+#define BUFSIZE (4*1024*1024)   /* Default blocksize, 4m */
+
 typedef enum {
     FILE_NOEXIST,
     FILE_REGULAR,
@@ -18,12 +22,27 @@ typedef enum {
 
 typedef enum { UP, DOWN } round_t;
 
+struct opt_struct {
+    const sequence_t *seq;
+    int blocksize;
+    off_t devsize;
+    char *dirent;
+    bool force;
+    bool nosig;
+    bool remove;
+    bool sparse;
+    bool nofollow;
+    bool nohwrand;
+    bool nothreads;
+};
+
 int         read_all(int fd, unsigned char *buf, int count);
 int         write_all(int fd, const unsigned char *buf, int count);
 int         is_symlink(char *path);
 filetype_t  filetype(char *path);
 off_t       blkalign(off_t offset, int blocksize, round_t rtype);
 void *      alloc_buffer(int bufsize);
+void        read_conf( struct opt_struct *opt );
 
 /*
  * vi:tabstop=4 shiftwidth=4 expandtab


### PR DESCRIPTION
Permits a configuration file to fix some program defaults. If not present, `scrub` performs as normal. If present, scrub will prefer options set and show set defaults in usage screen.

```
##### scrub.conf file #####
# Must Reside in: $HOME/.scrub.conf
# Lines beginning with # or space(s) ignored.
#
# Offers the following fixed parameters for scrub
#  BLOCKSIZE = number followed by Kk,Mm,Gg (-b 4m is default)
#  Block size limited to off_t, 2G
#  PATTERN = valid pattern name excl custom (-p pat)
#  FORCE = 0,1,FALSE,TRUE (-f)
#  NOSIGNATURE = 0,1,FALSE,TRUE (-S)
#  REMOVE = 0,1,FALSE,TRUE (-r)
#  NOLINK = 0,1,FALSE,TRUE (-L)
#  NOHWRAND = 0,1,FALSE,TRUE (-R)
#  NOTHREADS = 0,1,FALSE,TRUE (-t)
# valid patterns are: nnsa, dod, bsi, usarmy, random, random2
#  schneier, pfitzner7, pfitzner33, gutmann, fastold, old
#  dirent, fillzero, fillff, verify
# custom pattern strings not accepted
#
# Parameter names are case sensitive.
# Pattern value is case sensitive.
# Boolean words TRUE and FALSE are not case sensitive.
##### scrub.conf file #####
# default values shown. can be overridden on command line

#BLOCKSIZE=4m
#PATTERN=nnsa
#FORCE=FALSE
#NOSIGNATURE=FALSE
#REMOVE=FALSE
#NOLINK=FALSE
#NOHWRAND=FALSE
#NOTHREADS=FALSE
```