### PR TITLE
misc. build fixes

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -5,7 +5,6 @@ SUBDIRS += libscrub
 endif
 
 dist_doc_DATA = \
-	AUTHORS \
 	ChangeLog \
 	COPYING \
 	DISCLAIMER \

--- a/autogen.sh
+++ b/autogen.sh
@@ -3,7 +3,7 @@
 echo "Running aclocal ... "
 aclocal -I config
 
-if glibtoolize --version >/dev/null; then
+if glibtoolize --version 1>/dev/null 2>&1; then
   LIBTOOLIZE=glibtoolize
 fi
 LIBTOOLIZE=${LIBTOOLIZE:-libtoolize}

--- a/configure.ac
+++ b/configure.ac
@@ -2,7 +2,7 @@
 # Prologue
 ##
 AC_INIT([scrub],
-        m4_esyscmd([git describe --always | awk '/.*/ {sub(/^v/, ""); printf "%s",$1; exit}']))
+        m4_esyscmd([git describe --tags --always | awk '/.*/ {sub(/^v/, ""); printf "%s",$1; exit}']))
 
 AC_CONFIG_AUX_DIR([config])
 AC_CONFIG_SRCDIR([NEWS])

--- a/configure.ac
+++ b/configure.ac
@@ -14,6 +14,7 @@ X_AC_EXPAND_INSTALL_DIRS
 # Automake support
 ##
 AM_INIT_AUTOMAKE([subdir-objects foreign])
+AM_SILENT_RULES([yes])
 AM_CONFIG_HEADER([config/config.h])
 AM_MAINTAINER_MODE
 

--- a/configure.ac
+++ b/configure.ac
@@ -8,13 +8,12 @@ AC_CONFIG_AUX_DIR([config])
 AC_CONFIG_SRCDIR([NEWS])
 AC_CANONICAL_SYSTEM
 AC_CONFIG_MACRO_DIR([config])
-X_AC_META
 X_AC_EXPAND_INSTALL_DIRS
 
 ##
 # Automake support
 ##
-AM_INIT_AUTOMAKE([subdir-objects])
+AM_INIT_AUTOMAKE([subdir-objects foreign])
 AM_CONFIG_HEADER([config/config.h])
 AM_MAINTAINER_MODE
 

--- a/test/tgetsize.c
+++ b/test/tgetsize.c
@@ -20,6 +20,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <libgen.h>
+#include <string.h>
 
 #include "getsize.h"
 


### PR DESCRIPTION
Problem: #29 missed a couple of things needed to fully expunge AUTHORS and META from the build system.

Fix those here.

Also, increase the signal to noise ratio in the build output by setting AM_SILENT_RULES and fixing a build warning in a test program.

Note to @pete4abw:  the `git describe --always` output is 3d25926 currently.   This is because none of our tags were annotated tags.  I'll make sure the next tag is an annotated tag, and then we'll get the actual version when we make the dist tarball for the tag, and a version with the short commit appended for devel versions in between.  Here is a demonstration that a dist tarball still works after dropping META.
```
$ make dist
[snip]
$ tar xf scrub-c95e0b2.tar.gz
$ cd scrub-c95e0b2
$ ./configure
checking build system type... x86_64-pc-linux-gnu
checking host system type... x86_64-pc-linux-gnu
checking target system type... x86_64-pc-linux-gnu
checking installation directory variables... yes
checking for a BSD-compatible install... /usr/bin/install -c
checking whether build environment is sane... yes
checking for a thread-safe mkdir -p... /usr/bin/mkdir -p
checking for gawk... no
checking for mawk... mawk
checking whether make sets $(MAKE)... yes
checking whether make supports nested variables... yes
checking whether make supports nested variables... (cached) yes
checking whether to enable maintainer-specific portions of Makefiles... no
checking for gcc... gcc
checking whether the C compiler works... yes
checking for C compiler default output file name... a.out
checking for suffix of executables... 
checking whether we are cross compiling... no
checking for suffix of object files... o
checking whether we are using the GNU C compiler... yes
checking whether gcc accepts -g... yes
checking for gcc option to accept ISO C89... none needed
checking whether gcc understands -c and -o together... yes
checking whether make supports the include directive... yes (GNU style)
checking dependency style of gcc... gcc3
checking how to run the C preprocessor... gcc -E
checking for grep that handles long lines and -e... /usr/bin/grep
checking for egrep... /usr/bin/grep -E
checking for ANSI C header files... yes
checking for sys/types.h... yes
checking for sys/stat.h... yes
checking for stdlib.h... yes
checking for string.h... yes
checking for memory.h... yes
checking for strings.h... yes
checking for inttypes.h... yes
checking for stdint.h... yes
checking for unistd.h... yes
checking minix/config.h usability... no
checking minix/config.h presence... no
checking for minix/config.h... no
checking whether it is safe to define __EXTENSIONS__... yes
checking for ANSI C header files... (cached) yes
checking getopt.h usability... yes
checking getopt.h presence... yes
checking for getopt.h... yes
checking stdbool.h usability... yes
checking stdbool.h presence... yes
checking for stdbool.h... yes
checking for stdint.h... (cached) yes
checking pthread.h usability... yes
checking pthread.h presence... yes
checking for pthread.h... yes
checking linux/fs.h usability... yes
checking linux/fs.h presence... yes
checking for linux/fs.h... yes
checking sys/devinfo.h usability... no
checking sys/devinfo.h presence... no
checking for sys/devinfo.h... no
checking sys/disk.h usability... no
checking sys/disk.h presence... no
checking for sys/disk.h... no
checking sys/dkio.h usability... no
checking sys/dkio.h presence... no
checking for sys/dkio.h... no
checking sys/ioctl.h usability... yes
checking sys/ioctl.h presence... yes
checking for sys/ioctl.h... yes
checking sys/scsi.h usability... no
checking sys/scsi.h presence... no
checking for sys/scsi.h... no
checking sys/mman.h usability... yes
checking sys/mman.h presence... yes
checking for sys/mman.h... yes
checking how to print strings... printf
checking for a sed that does not truncate output... /usr/bin/sed
checking for fgrep... /usr/bin/grep -F
checking for ld used by gcc... /usr/bin/ld
checking if the linker (/usr/bin/ld) is GNU ld... yes
checking for BSD- or MS-compatible name lister (nm)... /usr/bin/nm -B
checking the name lister (/usr/bin/nm -B) interface... BSD nm
checking whether ln -s works... yes
checking the maximum length of command line arguments... 1572864
checking how to convert x86_64-pc-linux-gnu file names to x86_64-pc-linux-gnu format... func_convert_file_noop
checking how to convert x86_64-pc-linux-gnu file names to toolchain format... func_convert_file_noop
checking for /usr/bin/ld option to reload object files... -r
checking for objdump... objdump
checking how to recognize dependent libraries... pass_all
checking for dlltool... no
checking how to associate runtime and link libraries... printf %s\n
checking for ar... ar
checking for archiver @FILE support... @
checking for strip... strip
checking for ranlib... ranlib
checking command to parse /usr/bin/nm -B output from gcc object... ok
checking for sysroot... no
checking for a working dd... /usr/bin/dd
checking how to truncate binary pipes... /usr/bin/dd bs=4096 count=1
checking for mt... mt
checking if mt is a manifest tool... no
checking for dlfcn.h... yes
checking for objdir... .libs
checking if gcc supports -fno-rtti -fno-exceptions... no
checking for gcc option to produce PIC... -fPIC -DPIC
checking if gcc PIC flag -fPIC -DPIC works... yes
checking if gcc static flag -static works... yes
checking if gcc supports -c -o file.o... yes
checking if gcc supports -c -o file.o... (cached) yes
checking whether the gcc linker (/usr/bin/ld -m elf_x86_64) supports shared libraries... yes
checking whether -lc should be explicitly linked in... no
checking dynamic linker characteristics... GNU/Linux ld.so
checking how to hardcode library paths into programs... immediate
checking whether stripping libraries is possible... yes
checking if libtool supports shared libraries... yes
checking whether to build shared libraries... yes
checking whether to build static libraries... yes
checking whether to install pkg-config *.pc files... ${libdir}/pkgconfig
checking whether byte ordering is bigendian... no
checking for an ANSI C-conforming const... yes
checking for prop_dictionary_recv_ioctl in -lprop... no
checking for getopt_long... yes
checking for posix_memalign... yes
checking for memalign... yes
checking for posix_fadvise... yes
checking for rand_r... yes
checking for random_r... yes
checking how to link against pthreads... -lpthread
checking for libgcrypt-config... /usr/bin/libgcrypt-config
checking for LIBGCRYPT - version >= 1.5.0... yes (1.8.5)
checking for special C compiler options needed for large files... no
checking for _FILE_OFFSET_BITS value needed for large files... no
checking that generated files are newer than configure... done
configure: creating ./config.status
config.status: creating Makefile
config.status: creating scrub.spec
config.status: creating src/Makefile
config.status: creating man/Makefile
config.status: creating man/scrub.1
config.status: creating test/Makefile
config.status: creating libscrub/Makefile
config.status: creating libscrub/libscrub.pc
config.status: creating config/config.h
config.status: executing depfiles commands
config.status: executing libtool commands
$ make
Making all in src
make[1]: Entering directory '/home/garlick/proj/scrub/scrub-c95e0b2/src'
  CC       filldentry.o
  CC       fillfile.o
  CC       genrand.o
  CC       getsize.o
  CC       hwrand.o
  CC       pattern.o
  CC       progress.o
  CC       scrub.o
  CC       sig.o
  CC       util.o
  CCLD     scrub
make[1]: Leaving directory '/home/garlick/proj/scrub/scrub-c95e0b2/src'
Making all in man
make[1]: Entering directory '/home/garlick/proj/scrub/scrub-c95e0b2/man'
make[1]: Nothing to be done for 'all'.
make[1]: Leaving directory '/home/garlick/proj/scrub/scrub-c95e0b2/man'
Making all in test
make[1]: Entering directory '/home/garlick/proj/scrub/scrub-c95e0b2/test'
make[1]: Nothing to be done for 'all'.
make[1]: Leaving directory '/home/garlick/proj/scrub/scrub-c95e0b2/test'
make[1]: Entering directory '/home/garlick/proj/scrub/scrub-c95e0b2'
make[1]: Nothing to be done for 'all-am'.
make[1]: Leaving directory '/home/garlick/proj/scrub/scrub-c95e0b2'
$ make check
Making check in src
make[1]: Entering directory '/home/garlick/proj/scrub/scrub-c95e0b2/src'
make[1]: Nothing to be done for 'check'.
make[1]: Leaving directory '/home/garlick/proj/scrub/scrub-c95e0b2/src'
Making check in man
make[1]: Entering directory '/home/garlick/proj/scrub/scrub-c95e0b2/man'
make[1]: Nothing to be done for 'check'.
make[1]: Leaving directory '/home/garlick/proj/scrub/scrub-c95e0b2/man'
Making check in test
make[1]: Entering directory '/home/garlick/proj/scrub/scrub-c95e0b2/test'
make  pad trand tprogress tgetsize tsig tsize pat 
make[2]: Entering directory '/home/garlick/proj/scrub/scrub-c95e0b2/test'
  CC       pad.o
  CC       ../src/getsize.o
  CC       ../src/genrand.o
  CC       ../src/hwrand.o
  CC       ../src/util.o
  CC       ../src/progress.o
  CC       ../src/sig.o
  CCLD     pad
  CC       trand.o
  CCLD     trand
  CC       tprogress.o
  CCLD     tprogress
  CC       tgetsize.o
  CCLD     tgetsize
  CC       tsig.o
  CCLD     tsig
  CC       tsize.o
  CCLD     tsize
  CC       pat.o
  CCLD     pat
make[2]: Leaving directory '/home/garlick/proj/scrub/scrub-c95e0b2/test'
make  check-TESTS
make[2]: Entering directory '/home/garlick/proj/scrub/scrub-c95e0b2/test'
make[3]: Entering directory '/home/garlick/proj/scrub/scrub-c95e0b2/test'
PASS: t01
PASS: t02
PASS: t03
PASS: t04
PASS: t05
PASS: t06
PASS: t07
PASS: t08
SKIP: t09
SKIP: t10
PASS: t11
PASS: t12
PASS: t13
PASS: t14
PASS: t15
PASS: t16
PASS: t17
SKIP: t18
SKIP: t19
SKIP: t20
SKIP: t21
PASS: t22
============================================================================
Testsuite summary for scrub c95e0b2
============================================================================
# TOTAL: 22
# PASS:  16
# SKIP:  6
# XFAIL: 0
# FAIL:  0
# XPASS: 0
# ERROR: 0
============================================================================
make[3]: Leaving directory '/home/garlick/proj/scrub/scrub-c95e0b2/test'
make[2]: Leaving directory '/home/garlick/proj/scrub/scrub-c95e0b2/test'
make[1]: Leaving directory '/home/garlick/proj/scrub/scrub-c95e0b2/test'
make[1]: Entering directory '/home/garlick/proj/scrub/scrub-c95e0b2'
make[1]: Nothing to be done for 'check-am'.
make[1]: Leaving directory '/home/garlick/proj/scrub/scrub-c95e0b2'
```