### PR TITLE
Scrub link and remove fix: Scrub and remove both link and target.

### DIFF
--- a/src/util.c
+++ b/src/util.c
@@ -58,12 +58,23 @@ write_all(int fd, const unsigned char *buf, int count)
 }
 
 /* Indicates whether the file represented by 'path' is a symlink.
+ * and if so, return a pointer to the realpath.
  */
-int
+char *
 is_symlink(char *path)
 {
     struct stat sb;
-    return lstat(path, &sb) == 0 && S_ISLNK(sb.st_mode);
+    int error;
+    char *resolved_path;
+
+    if ((error = lstat(path, &sb)) != 0)
+        return NULL;	/* not a link */
+    if ((resolved_path=realpath(path,NULL)) == NULL)
+        return NULL;	/* some error in determining absolute path */
+    if (!S_ISLNK(sb.st_mode))  /* if it's not a link */
+	return NULL;
+
+    return resolved_path;
 }
 
 /* Return the type of file represented by 'path'.

--- a/src/util.h
+++ b/src/util.h
@@ -31,7 +31,7 @@ typedef enum { UP, DOWN } round_t;
 
 int         read_all(int fd, unsigned char *buf, int count);
 int         write_all(int fd, const unsigned char *buf, int count);
-int         is_symlink(char *path);
+char *      is_symlink(char *path);
 filetype_t  filetype(char *path);
 off_t       blkalign(off_t offset, int blocksize, round_t rtype);
 void *      alloc_buffer(int bufsize);


### PR DESCRIPTION
This addresses and issue where the -r option removes the link, but not the target. Now, both will be removed.

In addition, when -D newdir is used it renames the link but not the target. Now, it will rename the target.

When -D and -r are used together, both link and target will be removed.

(A follow up on #18 )