### PR TITLE
Add OpenSSL as an alternative to libgcrypt

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -84,19 +84,47 @@ AC_CHECK_FUNCS( \
 )
 X_AC_CHECK_PTHREADS
 
+
+# Sanity check; we cannot have both --with-libgcrypt AND --with-openssl
+# together.
+AS_IF([test "x$with_openssl" = "xyes"], [
+  AS_IF([test "x$with_libgcrypt" = "xyes"],
+    [AC_MSG_ERROR([You can use either --with-openssl or --with-libgcrypt, not both at once])]
+  )
+])
+
+##
+# OpenSSL libcrypto library
+##
+have_openssl=no
+AC_ARG_WITH(openssl, AS_HELP_STRING([--with-openssl], [build with OpenSSL libcrypto]))
+
+if test "x$with_openssl" = "xyes"; then
+  AC_SEARCH_LIBS([RAND_bytes], [crypto],
+    [AC_DEFINE([HAVE_OPENSSL], [1], [OpenSSL libcrypto available])
+      have_openssl=yes
+    ], [AC_MSG_ERROR([OpenSSL libcrypto required])]
+  )
+fi
+
 ##
 # gcrypt library
 ##
 have_libgcrypt=no
 AC_ARG_WITH(libgcrypt, AS_HELP_STRING([--without-libgcrypt], [build without libgcrypt;
                                          fallback to custom AES implementation]))
-AS_IF([test "x$with_libgcrypt" != "xno"],
-  [AM_PATH_LIBGCRYPT([1.5.0],
-    [AC_DEFINE([HAVE_LIBGCRYPT], [1], [libgcrypt API available])
-      gcrypt_CFLAGS="$LIBGCRYPT_CFLAGS"
-      gcrypt_LIBS="$LIBGCRYPT_LIBS"
-      have_libgcrypt=yes
-    ]
+
+# Technically there is no need for testing this again, as we already
+# error'ed out early if both options were enabled at once.
+AS_IF([test "x$with_openssl" != "xyes"], [
+  AS_IF([test "x$with_libgcrypt" != "xno"], [
+    AM_PATH_LIBGCRYPT([1.5.0],
+      [AC_DEFINE([HAVE_LIBGCRYPT], [1], [libgcrypt API available])
+        gcrypt_CFLAGS="$LIBGCRYPT_CFLAGS"
+        gcrypt_LIBS="$LIBGCRYPT_LIBS"
+        have_libgcrypt=yes
+      ]
+    )]
   )]
 )
 AM_CONDITIONAL([LIBGCRYPT], [test "$have_libgcrypt" = "yes"])

--- a/src/scrub.c
+++ b/src/scrub.c
@@ -453,13 +453,13 @@ scrub(char *path, off_t size, const sequence_t *seq, int bufsize,
             case PAT_RANDOM:
                 printf("%s: %-8s", prog, "random");
                 progress_create(&p, pcol);
-#ifndef HAVE_LIBGCRYPT
+#if !defined(HAVE_LIBGCRYPT) && !defined(HAVE_OPENSSL)
                 if (churnrand() < 0) {
                     fprintf(stderr, "%s: churnrand: %s\n", prog,
                              strerror(errno));
                     exit(1);
                 }
-#endif /* HAVE_LIBGCRYPT. */
+#endif /* !defined(HAVE_LIBGCRYPT) && !defined(HAVE_OPENSSL) */
                 written = fillfile(path, size, buf, bufsize,
                                    (progress_t)progress_update, p,
                                    (refill_t)genrand, sparse, enospc);


### PR DESCRIPTION
If OpenSSL is not explicitly required (ie.g with --with-openssl), the default keeps being:

1. try to use a HW random generator
2. attempt to use libgcrypt
3. fall back to custom AES implementation, if libgcrypt is not available

If OpenSSL is explictly required, step #2 replaces libgcrypt with openssl.